### PR TITLE
Updates for v3 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Here are the steps to get the host environment ready for this image:
 1. Login with user `pirate` and password `hypriot` *Note*: default keyboard layout is [QWERTY](https://en.wikipedia.org/wiki/QWERTY). If you are using a [QWERTZ](https://en.wikipedia.org/wiki/QWERTZ) keyboard make sure you use the correct 'y' in the password
 	* For SSH access: once the Pi has fully booted (the blinking LEDs have calmed down) it shows up with the default hostname `black-pearl` in your network.
 1. Run `sudo apt-get update && sudo apt-get install raspi-config kbd`. During setup you can choose a different keyboard layout if you need
-1. Run `sudo raspi-config` to 
-	* Set correct timezone: `4 Localisation Options > I2 Change Timezones` 
-	* Enable SPI interface: `5 Interfacing Options > P4 SPI > Yes` 
+1. Run `sudo raspi-config` to
+	* Set correct timezone: `4 Localisation Options > I2 Change Timezones`
+	* Enable SPI interface: `5 Interfacing Options > P4 SPI > Yes`
 1. Restart the Pi
 1. Find the Pi MAC address and generate gateway EUI (required in next step) by running `cat /sys/class/net/eth0/address | awk -F\: '{print $1$2$3"fffe"$4$5$6}'`. This turns the [48-bit MAC address into EUI-64](https://en.wikipedia.org/wiki/MAC_address#Address_details), splits it in half and injects `fffe` (e.g. `b827eb8684a2` → `b827ebfffe8684a2`).
 1. Run
 	```bash
 	docker run -it --privileged --net=host --restart=always \
 	-e PI_RESET_PIN=<optional-see-explanation-below> \
-	-e GATEWAY_REGION=<optional-see-explanation-below> \
+	-e TTN_GATEWAY_SERVER_URL=<optional-see-explanation-below> \
 	-e GATEWAY_EUI=<EUI-identified-in-previous-step> \
 	-e GATEWAY_LAT=YOUR_LATITUDE \
 	-e GATEWAY_LON=YOUR_LONGITUDE \
@@ -34,25 +34,13 @@ Here are the steps to get the host environment ready for this image:
 	-e GATEWAY_NAME=YOUR_GATEWAY_NAME \
 	netceteragroup/rpi-ttn-gateway
 	```
-	* `PI_RESET_PIN` may or may not be required depending on how the concentrator is connected to the Pi. The default 
-	reset pin configured by [the start script](https://github.com/ttn-zh/ic880a-gateway/blob/spi/start.sh#L4) is 25. 
-	Installations with simple backplanes such as [the one from Gnz](https://www.tindie.com/products/gnz/imst-ic880a-lorawan-backplane-kit/) 
-	 can go with the default value. More elaborate backplanes might rewire the reset pin. The [one from CH2i](https://github.com/ch2i/iC880A-Raspberry-PI) 
+	* `PI_RESET_PIN` may or may not be required depending on how the concentrator is connected to the Pi. The default
+	reset pin configured by [the start script](https://github.com/ttn-zh/ic880a-gateway/blob/spi/start.sh#L4) is 25.
+	Installations with simple backplanes such as [the one from Gnz](https://www.tindie.com/products/gnz/imst-ic880a-lorawan-backplane-kit/)
+	 can go with the default value. More elaborate backplanes might rewire the reset pin. The [one from CH2i](https://github.com/ch2i/iC880A-Raspberry-PI)
 	 for example uses 17. Hence, you would say `docker run ... -e PI_RESET_PIN=17 ...`.
-
-	* `GATEWAY_REGION` is optional and defaults to `EU`, it denotes the LoRaWAN region your gateway operates in according 
-	   to the below frequency table. The TTN server to use is derived from the region.
-
-	  |Region|Frequency                     |
-	  |:-----|:-----------------------------|
-	  |EU    |433 and 863-870 MHz           |
-	  |US    |America, 902-928 MHz          |
-	  |CN    |China, 470-510 and 779-787 MHz|
-	  |AU    |Australia, 915-928 MHz        |
-	  |AS    |Southeast Asia, 923 MHz       |
-	  |KR    |Korea, 920-923 MHz            |
-
-	  Check [The Things Network frequencies-by-country page](https://www.thethingsnetwork.org/wiki/LoRaWAN/Frequencies/By-Country) for details.
+	 * `TTN_GATEWAY_SERVER_URL` URL of the TTN API endpoint server to use, the default is `eu1.cloud.thetings.network`. Server address for other regions are listed here:
+  https://www.thethingsindustries.com/docs/getting-started/ttn/addresses/
 
 ## Running as a deamon
 Item 9 above documents the Docker run command. If you would rather want to run the TTN container in daemon mode rather than interactive mode you would replace `-dt` with `-it`. This will put the Docker container process into the background and not block the CLI but you won't see the log output that normally spills to the console.
@@ -64,7 +52,7 @@ To build a (potentially customized) image yourself do as follows:
 ```bash
 $ git clone https://github.com/netceteragroup/rpi-ttn-gateway
 $ cd rpi-ttn-gateway
-$ docker build -t <your-handle-here>/rpi-ttn-gateway . 
+$ docker build -t <your-handle-here>/rpi-ttn-gateway .
 ```
 `<your-handle-here>` can be anything that is uniquely you (e.g. name) but you might also use `rpi-ttn-gateway` w/o any "prefix".
 

--- a/cmd.sh
+++ b/cmd.sh
@@ -13,18 +13,10 @@ else
   fi
 fi
 
-defaultRegion="EU"
-if [ -z "$GATEWAY_REGION" ]; then
-  echo "GATEWAY_REGION env variable not set, using default region '$defaultRegion')"
-else
-  if [ "$GATEWAY_REGION" == $defaultRegion ]; then
-    echo "GATEWAY_REGION env variable is the same as the default region -> no changes"
-  else
-    echo "Setting gateway region to '$GATEWAY_REGION'"
-    region=$(echo "${GATEWAY_REGION}" | tr "[:upper:]" "[:lower:]")
-    sed -i -e "s/router.eu.thethings/router.$region.thethings/g" ./local_conf_template.json
-  fi
-fi
+# TTN API server options
+export TTN_GATEWAY_SERVER_URL=${TTN_GATEWAY_SERVER_URL:-eu1.cloud.thethings.network}
+export TTN_GATEWAY_PORT_UP=${TTN_GATEWAY_PORT_UP:-1700}
+export TTN_GATEWAY_PORT_DOWN=${TTN_GATEWAY_PORT_DOWN:-1700}
 
 # inject the values provided by the user into the template
 envsubst < local_conf_template.json > local_conf.json

--- a/local_conf_template.json
+++ b/local_conf_template.json
@@ -3,9 +3,9 @@
     "gateway_ID": "${GATEWAY_EUI}",
     "servers": [
       {
-        "server_address": "router.eu.thethings.network",
-        "serv_port_up": 1700,
-        "serv_port_down": 1700,
+        "server_address": "${TTN_GATEWAY_SERVER_URL}",
+        "serv_port_up": ${TTN_GATEWAY_PORT_UP},
+        "serv_port_down": ${TTN_GATEWAY_PORT_DOWN},
         "serv_enabled": true
       }
     ],


### PR DESCRIPTION
Hey there,

I just tried out to migrate the Gateway image to work with TTN v3 stack. Instead of `GATEWAY_REGION` you can now specify the TTN API Server URL (`TTN_GATEWAY_SERVER_URL`).

I tested it with this Gateway and it appears to work:
* Gateway model: https://shop.imst.de/wireless-modules/lora-products/36/lite-gateway-demonstration-platform-for-lora-technology
* TTN v3 Stack Gateway: https://eu1.cloud.thethings.network/console/gateways/eui-b827ebfffe42a733

I hope this is useful for you and please let me know if you have any feedback.

```bash
docker run -it --privileged --net=host --restart=always \
  -e PI_RESET_PIN=<optional-see-explanation-below> \
  -e TTN_GATEWAY_SERVER_URL=<optional-see-explanation-below> \
  -e GATEWAY_EUI=<EUI-identified-in-previous-step> \
  -e GATEWAY_LAT=YOUR_LATITUDE \
  -e GATEWAY_LON=YOUR_LONGITUDE \
  -e GATEWAY_ALT=YOUR_ALTITUDE \
  -e GATEWAY_EMAIL=YOUR_EMAIL \
  -e GATEWAY_NAME=YOUR_GATEWAY_NAME \
netceteragroup/rpi-ttn-gateway
```